### PR TITLE
NFC Routing to Tool pages

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -137,6 +137,7 @@ android {
 }
 
 dependencies {
+    compile project(':react-native-nfc-manager')
     compile project(':amazon-cognito-identity-js')
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation "com.android.support:appcompat-v7:${rootProject.ext.supportLibVersion}"

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -3,18 +3,29 @@
   <uses-permission android:name="android.permission.INTERNET" />
   <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
   <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+
   <application android:name=".MainApplication" android:label="@string/app_name" android:icon="@mipmap/ic_launcher" android:allowBackup="false" android:theme="@style/AppTheme">
     <activity android:name=".MainActivity" android:label="@string/app_name" android:configChanges="keyboard|keyboardHidden|orientation|screenSize" android:windowSoftInputMode="adjustResize">
+      
       <intent-filter>
         <action android:name="android.intent.action.MAIN" />
         <category android:name="android.intent.category.LAUNCHER" />
       </intent-filter>
+
       <intent-filter android:label="filter_react_native">
         <action android:name="android.intent.action.VIEW" />
         <category android:name="android.intent.category.DEFAULT" />
         <category android:name="android.intent.category.BROWSABLE" />
         <data android:scheme="creatio" android:host="tools" />
       </intent-filter>
+      
+      <intent-filter android:label="filter_react_native_nfc">
+        <action android:name="android.nfc.action.NDEF_DISCOVERED"/>
+        <category android:name="android.intent.category.DEFAULT"/>
+        <category android:name="android.intent.category.BROWSABLE" />
+        <data android:scheme="creatio" android:host="tools" />
+      </intent-filter>
+    
     </activity>
     <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" />
   </application>

--- a/android/app/src/main/java/com/aaltoapp/MainApplication.java
+++ b/android/app/src/main/java/com/aaltoapp/MainApplication.java
@@ -3,6 +3,7 @@ package com.aaltoapp;
 import android.app.Application;
 
 import com.facebook.react.ReactApplication;
+import community.revteltech.nfc.NfcManagerPackage;
 import com.amazonaws.RNAWSCognitoPackage;
 import com.facebook.react.ReactNativeHost;
 import com.facebook.react.ReactPackage;
@@ -24,6 +25,7 @@ public class MainApplication extends Application implements ReactApplication {
     protected List<ReactPackage> getPackages() {
       return Arrays.<ReactPackage>asList(
           new MainReactPackage(),
+            new NfcManagerPackage(),
             new RNAWSCognitoPackage()
       );
     }

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,4 +1,6 @@
 rootProject.name = 'AaltoApp'
+include ':react-native-nfc-manager'
+project(':react-native-nfc-manager').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-nfc-manager/android')
 include ':amazon-cognito-identity-js'
 project(':amazon-cognito-identity-js').projectDir = new File(rootProject.projectDir, '../node_modules/amazon-cognito-identity-js/android')
 

--- a/ios/AaltoApp.xcodeproj/project.pbxproj
+++ b/ios/AaltoApp.xcodeproj/project.pbxproj
@@ -66,6 +66,7 @@
 		0BEC7AC62EE948C2A76DE4F8 /* Raleway-Thin.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 8BD271B2BDA447B69A0D07E2 /* Raleway-Thin.ttf */; };
 		BE85139D21444C8199679BE4 /* Raleway-ThinItalic.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 5B578EA4AEDB4BDFB19F9591 /* Raleway-ThinItalic.ttf */; };
 		48E961A5B61946CFA0FC60EB /* libRNAWSCognito.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 99FFEFABE8B04AE5A5F57A46 /* libRNAWSCognito.a */; };
+		48658E8829F84416B2D76E15 /* libNfcManager.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5A357A07D8CA4CF2BE8DBD06 /* libNfcManager.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -401,6 +402,8 @@
 		5B578EA4AEDB4BDFB19F9591 /* Raleway-ThinItalic.ttf */ = {isa = PBXFileReference; name = "Raleway-ThinItalic.ttf"; path = "../src/assets/fonts/Raleway-ThinItalic.ttf"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = unknown; explicitFileType = undefined; includeInIndex = 0; };
 		F9668CF08E4F4831AEBCE44D /* RNAWSCognito.xcodeproj */ = {isa = PBXFileReference; name = "RNAWSCognito.xcodeproj"; path = "../node_modules/amazon-cognito-identity-js/ios/RNAWSCognito.xcodeproj"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = wrapper.pb-project; explicitFileType = undefined; includeInIndex = 0; };
 		99FFEFABE8B04AE5A5F57A46 /* libRNAWSCognito.a */ = {isa = PBXFileReference; name = "libRNAWSCognito.a"; path = "libRNAWSCognito.a"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = archive.ar; explicitFileType = undefined; includeInIndex = 0; };
+		F01C65E56BBC4E7A846BBA06 /* NfcManager.xcodeproj */ = {isa = PBXFileReference; name = "NfcManager.xcodeproj"; path = "../node_modules/react-native-nfc-manager/ios/NfcManager.xcodeproj"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = wrapper.pb-project; explicitFileType = undefined; includeInIndex = 0; };
+		5A357A07D8CA4CF2BE8DBD06 /* libNfcManager.a */ = {isa = PBXFileReference; name = "libNfcManager.a"; path = "libNfcManager.a"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = archive.ar; explicitFileType = undefined; includeInIndex = 0; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -429,6 +432,7 @@
 				00C302EA1ABCBA2D00DB3ED1 /* libRCTVibration.a in Frameworks */,
 				139FDEF61B0652A700C62182 /* libRCTWebSocket.a in Frameworks */,
 				48E961A5B61946CFA0FC60EB /* libRNAWSCognito.a in Frameworks */,
+				48658E8829F84416B2D76E15 /* libNfcManager.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -616,6 +620,7 @@
 				00C302DF1ABCB9EE00DB3ED1 /* RCTVibration.xcodeproj */,
 				139FDEE61B06529A00C62182 /* RCTWebSocket.xcodeproj */,
 				F9668CF08E4F4831AEBCE44D /* RNAWSCognito.xcodeproj */,
+				F01C65E56BBC4E7A846BBA06 /* NfcManager.xcodeproj */,
 			);
 			name = Libraries;
 			sourceTree = "<group>";
@@ -1309,10 +1314,12 @@
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"$(SRCROOT)/$(TARGET_NAME)\"",
+					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)\..\node_modules\amazon-cognito-identity-js\ios/**",
+					"$(SRCROOT)/../node_modules/react-native-nfc-manager/ios",
 				);
 			};
 			name = Debug;
@@ -1335,10 +1342,12 @@
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"$(SRCROOT)/$(TARGET_NAME)\"",
+					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)\..\node_modules\amazon-cognito-identity-js\ios/**",
+					"$(SRCROOT)/../node_modules/react-native-nfc-manager/ios",
 				);
 			};
 			name = Release;
@@ -1362,6 +1371,7 @@
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)\..\node_modules\amazon-cognito-identity-js\ios/**",
+					"$(SRCROOT)/../node_modules/react-native-nfc-manager/ios",
 				);
 			};
 			name = Debug;
@@ -1384,6 +1394,7 @@
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)\..\node_modules\amazon-cognito-identity-js\ios/**",
+					"$(SRCROOT)/../node_modules/react-native-nfc-manager/ios",
 				);
 			};
 			name = Release;
@@ -1414,10 +1425,12 @@
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"$(SRCROOT)/$(TARGET_NAME)\"",
+					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)\..\node_modules\amazon-cognito-identity-js\ios/**",
+					"$(SRCROOT)/../node_modules/react-native-nfc-manager/ios",
 				);
 			};
 			name = Debug;
@@ -1448,10 +1461,12 @@
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"$(SRCROOT)/$(TARGET_NAME)\"",
+					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)\..\node_modules\amazon-cognito-identity-js\ios/**",
+					"$(SRCROOT)/../node_modules/react-native-nfc-manager/ios",
 				);
 			};
 			name = Release;
@@ -1481,10 +1496,12 @@
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"$(SRCROOT)/$(TARGET_NAME)\"",
+					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)\..\node_modules\amazon-cognito-identity-js\ios/**",
+					"$(SRCROOT)/../node_modules/react-native-nfc-manager/ios",
 				);
 			};
 			name = Debug;
@@ -1514,10 +1531,12 @@
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"$(SRCROOT)/$(TARGET_NAME)\"",
+					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)\..\node_modules\amazon-cognito-identity-js\ios/**",
+					"$(SRCROOT)/../node_modules/react-native-nfc-manager/ios",
 				);
 			};
 			name = Release;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1250,7 +1250,7 @@
         },
         "array-equal": {
             "version": "1.0.0",
-            "resolved": "http://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
             "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM="
         },
         "array-filter": {
@@ -1579,7 +1579,7 @@
             "dependencies": {
                 "jsesc": {
                     "version": "1.3.0",
-                    "resolved": "http://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+                    "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
                     "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
                 }
             }
@@ -3676,7 +3676,7 @@
         },
         "event-target-shim": {
             "version": "1.1.1",
-            "resolved": "http://registry.npmjs.org/event-target-shim/-/event-target-shim-1.1.1.tgz",
+            "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-1.1.1.tgz",
             "integrity": "sha1-qG5e5r2qFgVEddp5fM3fDFVphJE="
         },
         "eventemitter3": {
@@ -3726,7 +3726,7 @@
         },
         "expand-range": {
             "version": "1.8.2",
-            "resolved": "http://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+            "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
             "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
             "requires": {
                 "fill-range": "^2.1.0"
@@ -4032,7 +4032,7 @@
         },
         "fs-extra": {
             "version": "1.0.0",
-            "resolved": "http://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
             "integrity": "sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA=",
             "requires": {
                 "graceful-fs": "^4.1.2",
@@ -8902,7 +8902,7 @@
         },
         "os-homedir": {
             "version": "1.0.2",
-            "resolved": "http://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+            "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
             "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
         },
         "os-locale": {
@@ -8917,7 +8917,7 @@
         },
         "os-tmpdir": {
             "version": "1.0.2",
-            "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+            "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
             "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
         },
         "output-file-sync": {
@@ -9008,7 +9008,7 @@
         },
         "path-is-absolute": {
             "version": "1.0.1",
-            "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
             "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
         },
         "path-is-inside": {
@@ -9528,6 +9528,11 @@
                 "opencollective": "^1.0.3",
                 "prop-types": "^15.5.8"
             }
+        },
+        "react-native-nfc-manager": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/react-native-nfc-manager/-/react-native-nfc-manager-1.1.1.tgz",
+            "integrity": "sha512-5hnmdrf6TvUzjBUSsr6wFdjwIfmSypjJZ3QQJuHZZfAoIrVFVkIBQSecbNCcVE0CbB+dgqsED9H6GrBLIypYiA=="
         },
         "react-native-safe-area-view": {
             "version": "0.11.0",
@@ -10152,7 +10157,7 @@
         },
         "require-uncached": {
             "version": "1.0.3",
-            "resolved": "http://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+            "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
             "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
             "requires": {
                 "caller-path": "^0.1.0",
@@ -10723,7 +10728,7 @@
         },
         "simple-plist": {
             "version": "0.2.1",
-            "resolved": "http://registry.npmjs.org/simple-plist/-/simple-plist-0.2.1.tgz",
+            "resolved": "https://registry.npmjs.org/simple-plist/-/simple-plist-0.2.1.tgz",
             "integrity": "sha1-cXZts1IyaSjPOoByQrp2IyJjZyM=",
             "requires": {
                 "bplist-creator": "0.0.7",
@@ -11086,7 +11091,7 @@
         },
         "string_decoder": {
             "version": "1.1.1",
-            "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
             "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
             "requires": {
                 "safe-buffer": "~5.1.0"

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
         "prop-types": "^15.6.2",
         "react": "^16.6.0-alpha.8af6728",
         "react-native": "0.57.4",
+        "react-native-nfc-manager": "^1.1.1",
         "react-navigation": "^1.0.0",
         "react-redux": "^5.0.6",
         "react-test-renderer": "^16.6.0-alpha.8af6728",

--- a/src/nav/Home.js
+++ b/src/nav/Home.js
@@ -1,3 +1,5 @@
+/* eslint-disable react/no-unused-state */
+/* eslint-disable no-console */
 /* eslint-disable react/jsx-no-bind */
 import React from 'react'
 import {
@@ -12,7 +14,7 @@ import {
 
 import { connect } from 'react-redux'
 import { Auth } from 'aws-amplify'
-
+import NfcManager, {Ndef} from 'react-native-nfc-manager'
 import { logOut } from '../actions'
 import { colors, fonts } from '../theme'
 
@@ -34,6 +36,29 @@ class Home extends React.Component {
 		} else {
 			Linking.addEventListener('url', this.handleOpenURL)
 		}
+		NfcManager.start({
+			onSessionClosedIOS: () => {
+				console.log('ios session closed')
+			}
+		})
+			.then(result => {
+				console.log('start OK', result)
+			})
+			.catch(error => {
+				console.warn('device does not support nfc!', error)
+				this.setState({supported: false})
+			})
+		NfcManager.getLaunchTagEvent()
+			.then(tag => {
+				const uri = this.parseUri(tag)
+				console.log('Launch tag:', uri)
+				if (uri) {
+					this.navigate(uri)
+				}
+			})
+			.catch(error => {
+				console.log(error)
+			})
 	}
 
 	componentWillUnmount() {
@@ -43,6 +68,17 @@ class Home extends React.Component {
 	handleOpenURL = event => {
 		this.navigate(event.url)
 	}
+  
+  parseUri = (tag) => {
+  	try {
+  		if (Ndef.isType(tag.ndefMessage[0], Ndef.TNF_WELL_KNOWN, Ndef.RTD_URI)) {
+  			return Ndef.uri.decodePayload(tag.ndefMessage[0].payload)
+  		}
+  	} catch (e) {
+  		console.log(e)
+  	}
+  	return null
+  }
 
 	navigate = url => {
 		// eslint-disable-next-line react/prop-types
@@ -81,29 +117,29 @@ class Home extends React.Component {
 		})
 	}
 	render() {
-		return (
-			<View style={styles.container}>
-				<View style={styles.homeContainer}>
-					<Text style={styles.welcome}>Welcome</Text>
-					<Animated.Image
-						source={require('../assets/boomboxcropped.png')}
-						style={{
-							tintColor: colors.primary,
-							width: width / 2,
-							height: width / 2,
-							transform: [{ scale: this.AnimatedScale }]
-						}}
-						resizeMode="contain"
-					/>
-					<Text
-						onPress={this.logout.bind(this)}
-						style={styles.welcome}
-					>
+  	return (
+  		<View style={styles.container}>
+  			<View style={styles.homeContainer}>
+  				<Text style={styles.welcome}>Welcome</Text>
+  				<Animated.Image
+  					source={require('../assets/boomboxcropped.png')}
+  					style={{
+  						tintColor: colors.primary,
+  						width: width / 2,
+  						height: width / 2,
+  						transform: [{ scale: this.AnimatedScale }]
+  					}}
+  					resizeMode="contain"
+  				/>
+  				<Text
+  					onPress={this.logout.bind(this)}
+  					style={styles.welcome}
+  				>
 						Logout
-					</Text>
-				</View>
-			</View>
-		)
+  				</Text>
+  			</View>
+  		</View>
+  	)
 	}
 }
 


### PR DESCRIPTION
### Route user to tool pages by tapping a NFC tag

NFC routing to tool pages works on Android version. Tapping NFC tag with URI to tool routes user to the correct tool page. Captures the Launch Tag Event with `getLaunchTagEvent()` so this should work anywhere in the OS without the app open.

Also `NDEF_DISCOVERED` -intent-filter in the AndroidManifest.xml makes sure that application catches the tag event before Android Tags does.